### PR TITLE
Bundle gb-call per-skill so npx-installed agents can resolve it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,14 +43,15 @@ The Guardrails section of each SKILL.md is an API-quirk catalog disguised as pol
 
 ## What this repo is
 
-A Claude Code plugin (`growthbook`) that ships agent skills for GrowthBook feature flags and experimentation. Skills shell out to a small Node helper (`scripts/gb-call`) that calls the GrowthBook REST API directly. No MCP server, no build step, no runtime deps beyond Node 18+.
+A Claude Code plugin (`growthbook`) that also ships as standalone agent skills for GrowthBook feature flags and experimentation. Skills shell out to a small Node helper (`scripts/gb-call`) that calls the GrowthBook REST API directly. The helper is also bundled per-skill at `skills/<name>/scripts/gb-call` so agents installed via `npx skills install` (Cursor, Codex, etc.) can resolve it relative to the skill directory. No MCP server, no build step, no runtime deps beyond Node 18+.
 
 ## Architecture in one breath
 
 ```
-skills/<name>/SKILL.md   ← workflow + guardrails (the entire skill)
-scripts/gb-call          ← only thing skills are allowed to shell out to
-.claude-plugin/          ← plugin.json (manifest) + marketplace.json (listing)
+skills/<name>/SKILL.md             ← workflow + guardrails (the entire skill)
+skills/<name>/scripts/gb-call      ← per-skill copy; npx-installed agents use this
+scripts/gb-call                    ← canonical helper; Claude plugin invokes this
+.claude-plugin/                    ← plugin.json (manifest) + marketplace.json (listing)
 ```
 
 Skills are pure markdown. The helper is the only executable code in the plugin. This is intentional — the v0.2.0 commit (`daac766`) pivoted away from MCP to keep the surface that small.
@@ -70,8 +71,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 <one-paragraph intent: what this skill does and what it deliberately doesn't>
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`.
-It expects `GB_API_KEY` in env.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It expects `GB_API_KEY` in env.
 
 ## Workflow
 <numbered steps, with bash + JSON shown literally>
@@ -91,7 +91,7 @@ It expects `GB_API_KEY` in env.
 - **`description` does routing, not labeling.** Include (a) concrete trigger phrases the user might say, and (b) explicit "For X, use Y skill" handoff hints. Look at any existing skill — the description is dense by design. It's what teaches Claude when *not* to fire.
 - **`allowed-tools` is the security model.** Pin to `Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)` and nothing else, unless the skill genuinely needs another binary. Two existing exceptions: `experiment-analyze` allows `Bash(sleep *)` for its poll loop; `gb-setup` allows four file-management commands to write `~/.config/growthbook/.env`. New tool grants need a defensible reason.
 - **When you do grant another binary, prefer literal full-command patterns over wildcards.** `Bash(chmod 600 ~/.config/growthbook/.env)` is a much narrower grant than `Bash(chmod *)` — the latter would allow `chmod 777 ~/.ssh/authorized_keys` if a prompt-injected response asked Claude to run it. Wildcards are only appropriate when the variable portion is genuinely unbounded (e.g. `Bash(sleep *)` where the arg is a duration). For everything else, write out each accepted invocation as its own allowlist entry.
-- **Use `${CLAUDE_PLUGIN_ROOT}` for paths**, never relative paths. It resolves to the plugin's install directory at runtime.
+- **Use `${CLAUDE_PLUGIN_ROOT}` for paths in `allowed-tools` and the Claude-install line of the intro paragraph.** It resolves to the plugin's install directory at runtime. The intro paragraph also documents the `scripts/gb-call` path relative to the skill directory for `npx skills install` agents — see the SKILL.md template above. `allowed-tools` itself stays Claude-pinned; other agents ignore it.
 
 ### Workflow conventions
 
@@ -182,6 +182,16 @@ Resist the urge to add features. `scripts/README.md` lists what is **not in scop
 - No multi-profile support (one `~/.config/growthbook/.env`, no `GB_PROFILE`)
 
 Each of these gets added only when a real skill needs it. `experiment-analyze` will probably be the first caller that justifies retry/backoff.
+
+## Per-skill helper copies (stopgap)
+
+The helper lives in two places: the canonical `scripts/gb-call` (what the Claude plugin invokes via `${CLAUDE_PLUGIN_ROOT}`), and a per-skill copy at `skills/<name>/scripts/gb-call` (what agents installed via `npx skills install` resolve relative to the skill directory). The duplication exists because `${CLAUDE_PLUGIN_ROOT}` is Claude-specific and doesn't resolve in Cursor, Codex, or other agents.
+
+**Workflow:** edit canonical `scripts/gb-call`, then copy the new contents into every `skills/<name>/scripts/gb-call` and `chmod 755` each one — by hand, or by asking Claude to do it. Non-Claude agents invoke the helper via `./scripts/gb-call`, so the executable bit matters. We expect this manual sync to happen once or twice at most before the CLI replacement lands.
+
+**No CI, no sync script — by design.** This is an intentionally minimal stopgap until a proper CLI replaces the whole install/distribution architecture. If you find yourself wanting to add tooling around the duplication (a sync script, a CI drift check, a refactor that collapses the per-skill copies), **don't**. Let the next CLI iteration solve it cleanly rather than half-solving it in the stopgap.
+
+If the per-skill copies drift from the canonical, npx-installed agents get the stale helper while Claude users get the fresh one. The bar before merging a `scripts/gb-call` change is "all 23 per-skill copies are byte-identical and `+x`."
 
 ## Naming and lifecycle
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Each skill's description names its trigger phrases and routes to sibling skills 
 
 ## How it works
 
-The plugin bundles a small Node helper (`scripts/gb-call`) that handles auth, base URL, and error reporting for every REST request. Skills call it via Bash:
+The plugin bundles a small Node helper (`scripts/gb-call`) that handles auth, base URL, and error reporting for every REST request. The helper is also bundled per-skill at `skills/<name>/scripts/gb-call` so agents installed via `npx skills install` (Cursor, Codex, etc.) can resolve it relative to the skill directory. Skills call it via Bash:
 
 ```bash
 gb-call GET /api/v2/features
@@ -141,6 +141,9 @@ scripts/
   gb-call                              # Node REST helper (zero deps, Node 18+)
   README.md                            # gb-call usage, config sources, error catalog
 skills/
+  <name>/
+    SKILL.md                           # workflow + guardrails
+    scripts/gb-call                    # per-skill copy for npx-installed agents
   gb-setup/SKILL.md                    # one-time onboarding
 
   # Revision lifecycle

--- a/skills/experiment-analyze/SKILL.md
+++ b/skills/experiment-analyze/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *) Bash(sleep *)
 
 Fetch results, refresh the snapshot only when the cached data is over 24 hours old or the user wants a different phase/dimension cut, then interpret. This skill is the heaviest in the catalog because of the conditional polling loop and the statistical interpretation — slow down and do each step deliberately.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`. The skill also uses `sleep` between poll calls.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`. The skill also uses `sleep` between poll calls.
 
 ## Workflow
 

--- a/skills/experiment-analyze/scripts/gb-call
+++ b/skills/experiment-analyze/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/experiment-brainstorm/SKILL.md
+++ b/skills/experiment-brainstorm/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Propose new experiment ideas grounded in the team's past stopped experiments. Read history first; propose based on what actually moved metrics, where guardrails failed, and which tags or projects under-explored.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/experiment-brainstorm/scripts/gb-call
+++ b/skills/experiment-brainstorm/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/experiment-design/SKILL.md
+++ b/skills/experiment-design/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Help the user produce an experiment spec that's actually launchable. Walk them through hypothesis, variations, metrics, and sample-size sanity. This skill does **not** write to GrowthBook — it ends with a ready-to-launch spec that `experiment-launch` consumes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/experiment-design/scripts/gb-call
+++ b/skills/experiment-design/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/experiment-launch/SKILL.md
+++ b/skills/experiment-launch/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Launch a GrowthBook A/B test end-to-end: create the experiment in draft, prep or reuse the feature flag, add the experiment-ref rule on a fresh draft revision, then call `/start` to publish the rule and flip the experiment to running. Handles the approval-required and pre-launch-checklist failure paths.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:setup`.
 
 ## Required inputs
 

--- a/skills/experiment-launch/scripts/gb-call
+++ b/skills/experiment-launch/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/experiment-stop/SKILL.md
+++ b/skills/experiment-stop/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Stop a running experiment, optionally declaring a winning variation and ramping it to all eligible traffic via a temporary rollout. The endpoint is `POST /api/v1/experiments/<id>/stop` (a dedicated endpoint, not the generic update). All variation references are **variation ID strings** like `var_abc123`, not 0-based integer indexes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/experiment-stop/scripts/gb-call
+++ b/skills/experiment-stop/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-cleanup/SKILL.md
+++ b/skills/flag-cleanup/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Archive or delete a stale feature flag. Two paths: **archive** (reversible, soft-disable) or **delete** (permanent; always goes through archive first as a safety gate). The skill coordinates code-cleanup with the agent's general Read/Edit tools, surfacing call sites from GrowthBook's Code References API (when configured) or falling back to Grep against the user's current directory.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
 
 ## Required inputs
 

--- a/skills/flag-cleanup/scripts/gb-call
+++ b/skills/flag-cleanup/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-create/SKILL.md
+++ b/skills/flag-create/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Create a new feature flag in GrowthBook. We always set `{enabled: false}` for every environment explicitly in the payload, so the flag ships disabled regardless of the org's default-state-for-new-environments setting — the user must enable it after creation. Feature keys are permanent; pick the name carefully.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/flag-create/scripts/gb-call
+++ b/skills/flag-create/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-default-value/SKILL.md
+++ b/skills/flag-default-value/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Set the default value of a GrowthBook feature flag. The default value is what the SDK returns when no rules match a user — it's the flag's baseline state, not a targeting rule. Changes go through a draft revision and require publishing before they take effect.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Required inputs
 

--- a/skills/flag-default-value/scripts/gb-call
+++ b/skills/flag-default-value/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-experiment/SKILL.md
+++ b/skills/flag-experiment/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Add an `experiment-ref` rule to a GrowthBook feature flag. This links a flag rule to a separately-managed GrowthBook experiment object — the experiment is the source of truth for variations, metrics, and analysis.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/flag-experiment/scripts/gb-call
+++ b/skills/flag-experiment/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-graph/SKILL.md
+++ b/skills/flag-graph/SKILL.md
@@ -10,7 +10,7 @@ Trace the dependency relationships around a GrowthBook feature flag. Use this sk
 
 Read-only — this skill never writes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/flag-graph/scripts/gb-call
+++ b/skills/flag-graph/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-metadata/SKILL.md
+++ b/skills/flag-metadata/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Update the administrative metadata of an existing GrowthBook feature flag. Metadata changes (description, owner, project, tags, custom fields, JSON schema) go through a draft revision like all other flag changes — they need to be published before they take effect.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Required inputs
 

--- a/skills/flag-metadata/scripts/gb-call
+++ b/skills/flag-metadata/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-monitoring/SKILL.md
+++ b/skills/flag-monitoring/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *), Bash(open https://
 
 Set up and manage a monitored progressive rollout (also called a "safe rollout") for a GrowthBook feature flag. A safe rollout is a standard `rollout` rule with a multi-step ramp schedule and `monitoringConfig` attached — the monitoring watches guardrail metrics at each step and can signal or automatically trigger a rollback if regressions are detected.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Required inputs for monitoring configuration
 

--- a/skills/flag-monitoring/scripts/gb-call
+++ b/skills/flag-monitoring/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-prerequisites/SKILL.md
+++ b/skills/flag-prerequisites/SKILL.md
@@ -12,7 +12,7 @@ Add, remove, or inspect feature-level prerequisites on a GrowthBook feature flag
 
 This is distinct from rule-level prerequisites (which gate a single rule and support richer conditions) — feature-level prerequisites apply to every rule on the flag simultaneously.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/flag-prerequisites/scripts/gb-call
+++ b/skills/flag-prerequisites/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-publish/SKILL.md
+++ b/skills/flag-publish/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *), Bash(open https://
 
 Get a GrowthBook feature flag draft revision live, or undo a change. Handles the full publish flow including the two common failure modes — approval-required (blocked) and merge conflict (stale base) — and the escape hatches: discard and revert.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/flag-publish/scripts/gb-call
+++ b/skills/flag-publish/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-ramp/SKILL.md
+++ b/skills/flag-ramp/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *), Bash(open https://
 
 Create and manage multi-step ramp schedules for a GrowthBook feature flag rule. A ramp schedule progressively increases (or decreases) a rule's traffic coverage over time, with defined hold intervals between steps. Steps can be manual (operator advances them) or time-gated (auto-advance after an interval).
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## How ramp schedules work
 

--- a/skills/flag-ramp/scripts/gb-call
+++ b/skills/flag-ramp/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-review/SKILL.md
+++ b/skills/flag-review/SKILL.md
@@ -10,7 +10,7 @@ Request and submit approval reviews on GrowthBook feature flag draft revisions. 
 
 Two roles use this skill: the **drafter** (requests a review, can't self-approve) and the **reviewer** (submits the review decision).
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Approval flow
 

--- a/skills/flag-review/scripts/gb-call
+++ b/skills/flag-review/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-revisions/SKILL.md
+++ b/skills/flag-revisions/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Inspect and manage draft revisions on GrowthBook feature flags. Every flag change goes through a draft revision before going live — this is the "what's in flight?" skill. Use it to see open drafts, understand their status, and manage their lifecycle (create, discard). Making actual flag changes (rules, metadata, toggles, default value) is handled by the relevant flag-* write skills, which create and manage drafts automatically.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Revision status reference
 

--- a/skills/flag-revisions/scripts/gb-call
+++ b/skills/flag-revisions/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-rules/SKILL.md
+++ b/skills/flag-rules/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Entry point for rule operations on a GrowthBook feature flag. Use this skill to inspect rules, delete a rule, or reorder rules. For creating or editing rules, this skill identifies the right rule type and routes to the specialized skill.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Rule types reference
 

--- a/skills/flag-rules/scripts/gb-call
+++ b/skills/flag-rules/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-schedule/SKILL.md
+++ b/skills/flag-schedule/SKILL.md
@@ -10,7 +10,7 @@ Add a timed activation window to a GrowthBook feature flag rule. A scheduled rul
 
 Scheduling applies to `force` and `rollout` rule types. It does not apply to `experiment-ref` or `safe-rollout` rules.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## How scheduling works
 

--- a/skills/flag-schedule/scripts/gb-call
+++ b/skills/flag-schedule/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-search/SKILL.md
+++ b/skills/flag-search/SKILL.md
@@ -10,7 +10,7 @@ Search, list, and audit GrowthBook feature flags. Three jobs share this skill: b
 
 Read-only — this skill never writes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Workflow
 

--- a/skills/flag-search/scripts/gb-call
+++ b/skills/flag-search/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-targeting/SKILL.md
+++ b/skills/flag-targeting/SKILL.md
@@ -10,7 +10,7 @@ Add, edit, or remove targeting rules on an existing GrowthBook feature flag. Han
 
 Every change goes through a draft revision and requires publishing. For publishing, use flag-publish — it handles approval-required and merge-conflict failure modes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Required inputs
 

--- a/skills/flag-targeting/scripts/gb-call
+++ b/skills/flag-targeting/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/flag-toggle/SKILL.md
+++ b/skills/flag-toggle/SKILL.md
@@ -10,7 +10,7 @@ Enable or disable a GrowthBook feature flag in a specific environment. Toggling 
 
 Like all flag changes, environment toggles go through the draft → review → publish flow. There is no bypass path — review is the happy path, not an obstacle.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
 
 ## Required inputs
 

--- a/skills/flag-toggle/scripts/gb-call
+++ b/skills/flag-toggle/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();

--- a/skills/gb-setup/SKILL.md
+++ b/skills/gb-setup/SKILL.md
@@ -12,6 +12,8 @@ The API key is a Personal Access Token (PAT) tied to a GrowthBook user, so the A
 
 `gb-call` reads this file when the corresponding environment variables aren't set, so the user gets a one-time config rather than editing their shell rc. Real environment variables always win over the file — useful for CI and one-off overrides.
 
+Below, `gb-call` refers to the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory.
+
 ## Workflow
 
 1. **Detect current state.** Check what's already configured. Don't ask the user for values they already have unless they want to change them.
@@ -70,7 +72,7 @@ The API key is a Personal Access Token (PAT) tied to a GrowthBook user, so the A
    ```bash
    GB_API_KEY='<value>' \
    GB_API_URL='<value or empty>' \
-     ${CLAUDE_PLUGIN_ROOT}/scripts/gb-call GET /api/v1/projects
+     gb-call GET /api/v1/projects
    ```
 
    Interpret the result:

--- a/skills/gb-setup/scripts/gb-call
+++ b/skills/gb-setup/scripts/gb-call
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// gb-call — minimal REST client for the GrowthBook API.
+//
+// Every `growthbook` plugin skill calls this. Reads GB_API_KEY (and optional
+// GB_API_URL) from env first, falling back to ~/.config/growthbook/.env
+// when env vars are unset. Env always wins over the file (POSIX convention).
+// On non-2xx, writes a targeted error to stderr that points at /growthbook:setup
+// when the failure looks like a config problem.
+//
+// Usage:
+//   gb-call <METHOD> <PATH> [BODY_FILE | -]
+//
+// Examples:
+//   gb-call GET /api/v1/features
+//   gb-call GET '/api/v1/features?limit=50&projectId=prj_abc'
+//   gb-call POST /api/v1/features ./payload.json
+//   echo '{"id":"foo","valueType":"boolean"}' | gb-call POST /api/v1/features -
+//
+// Config sources (in precedence order):
+//   1. process.env.GB_API_KEY / GB_API_URL
+//   2. ~/.config/growthbook/.env  (KEY=value per line; written by /growthbook:setup)
+
+const { readFileSync, existsSync } = require("node:fs");
+const { homedir } = require("node:os");
+const { join } = require("node:path");
+
+function die(msg, code = 2) {
+  process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+  process.exit(code);
+}
+
+// Parse KEY=value lines from ~/.config/growthbook/.env. Ignore blanks and #-comments.
+// No quoting handling — values are verbatim from the first `=` to end of line.
+function loadEnvFile() {
+  const path = join(homedir(), ".config", "growthbook", ".env");
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const raw of readFileSync(path, "utf8").split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+const fileEnv = loadEnvFile();
+const apiKey = process.env.GB_API_KEY || fileEnv.GB_API_KEY;
+const apiUrl = process.env.GB_API_URL || fileEnv.GB_API_URL || "https://api.growthbook.io";
+
+if (!apiKey) {
+  die(
+    "GB_API_KEY is not set.\n" +
+      "Run /growthbook:setup to configure it, or export GB_API_KEY in your shell.",
+  );
+}
+
+// Reject values containing whitespace or control characters. Real GrowthBook
+// PATs are alphanumeric with `_`/`-`, and a URL has no business containing
+// either. CRLF in apiKey would inject arbitrary headers via the Authorization
+// header; junk in apiUrl would silently corrupt every request.
+const CONTROL_RE = /[\s\x00-\x1f\x7f]/;
+if (CONTROL_RE.test(apiKey)) {
+  die(
+    "GB_API_KEY contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+if (CONTROL_RE.test(apiUrl)) {
+  die(
+    "GB_API_URL contains whitespace or control characters.\n" +
+      "Re-run /growthbook:setup to set a clean value.",
+  );
+}
+
+const base = apiUrl.replace(/\/$/, "");
+
+const [method, path, bodyArg] = process.argv.slice(2);
+if (!method || !path) {
+  die("Usage: gb-call <METHOD> <PATH> [BODY_FILE | -]");
+}
+
+const upperMethod = method.toUpperCase();
+if (!["GET", "POST", "PUT", "PATCH", "DELETE"].includes(upperMethod)) {
+  die(`Unknown method: ${method}`);
+}
+
+let body;
+if (bodyArg === "-") {
+  body = readFileSync(0, "utf8");
+} else if (bodyArg) {
+  try {
+    body = readFileSync(bodyArg, "utf8");
+  } catch (e) {
+    die(`Cannot read body file ${bodyArg}: ${e.message}`);
+  }
+}
+
+const url = `${base}${path.startsWith("/") ? path : "/" + path}`;
+const headers = {
+  Authorization: `Bearer ${apiKey}`,
+  Accept: "application/json",
+};
+if (body) headers["Content-Type"] = "application/json";
+
+// Translate common HTTP failures into actionable hints. Each branch returns
+// the full message that gets written to stderr before exiting.
+function explainHttpError(status, statusText, responseBody, requestUrl) {
+  const host = (() => {
+    try { return new URL(requestUrl).host; } catch { return requestUrl; }
+  })();
+  const isCloud = host === "api.growthbook.io";
+
+  if (status === 401 || status === 403) {
+    return (
+      `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Authentication failed. Your GB_API_KEY may be invalid, expired, or revoked.\n` +
+      `Run /growthbook:setup to refresh it.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 404 && isCloud) {
+    return (
+      `HTTP 404 on ${upperMethod} ${requestUrl}\n` +
+      `Got 404 from api.growthbook.io. If you're using a self-hosted GrowthBook instance,\n` +
+      `run /growthbook:setup to configure GB_API_URL.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  if (status === 429) {
+    return (
+      `HTTP 429 ${statusText} on ${upperMethod} ${requestUrl}\n` +
+      `Rate limited (60 requests/minute). Wait a moment and retry.\n` +
+      (responseBody ? responseBody + "\n" : "")
+    );
+  }
+  // Fall-through — show the raw error.
+  return (
+    `HTTP ${status} ${statusText} on ${upperMethod} ${requestUrl}\n` +
+    (responseBody ? responseBody + "\n" : "")
+  );
+}
+
+(async () => {
+  let res;
+  try {
+    res = await fetch(url, { method: upperMethod, headers, body });
+  } catch (e) {
+    die(`Request failed: ${e.message}`, 1);
+  }
+  const text = await res.text();
+  if (!res.ok) {
+    process.stderr.write(explainHttpError(res.status, res.statusText, text, url));
+    process.exit(1);
+  }
+  process.stdout.write(text);
+})();


### PR DESCRIPTION
Bundle the `gb-call` helper with each skill so that skills installed via `npx skills` work across agents. This is a stopgap until we refactor to leverage an updated CLI.