### PR TITLE
Use git symlinks for per-skill gb-call; fix ramp payload examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ scripts/gb-call                    ← canonical helper; Claude plugin invokes t
 
 Skills are pure markdown. The helper is the only executable code in the plugin. This is intentional — the v0.2.0 commit (`daac766`) pivoted away from MCP to keep the surface that small.
 
-Each `skills/<name>/scripts/gb-call` is a **git symlink** pointing to `../../../scripts/gb-call`. When agents install via `npx skills install` (Cursor, Codex, etc.), the installer dereferences symlinks (`cp` with `dereference: true`) and writes a real file at the destination — the agent sees a plain executable and has no knowledge of the symlink. Edit only the canonical `scripts/gb-call`; the per-skill symlinks update automatically.
+The per-skill `scripts/gb-call` entries are git symlinks — edit only the canonical `scripts/gb-call`. Never create copies in skill directories.
 
 ## The skill contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,17 +43,20 @@ The Guardrails section of each SKILL.md is an API-quirk catalog disguised as pol
 
 ## What this repo is
 
-A Claude Code plugin (`growthbook`) that ships agent skills for GrowthBook feature flags and experimentation. Skills shell out to a small Node helper (`scripts/gb-call`) that calls the GrowthBook REST API directly. No MCP server, no build step, no runtime deps beyond Node 18+.
+A Claude Code plugin (`growthbook`) that also ships as standalone agent skills for GrowthBook feature flags and experimentation. Skills shell out to a small Node helper (`scripts/gb-call`) that calls the GrowthBook REST API directly. No MCP server, no build step, no runtime deps beyond Node 18+.
 
 ## Architecture in one breath
 
 ```
-skills/<name>/SKILL.md   ← workflow + guardrails (the entire skill)
-scripts/gb-call          ← only thing skills are allowed to shell out to
-.claude-plugin/          ← plugin.json (manifest) + marketplace.json (listing)
+skills/<name>/SKILL.md             ← workflow + guardrails (the entire skill)
+skills/<name>/scripts/gb-call      ← symlink → ../../scripts/gb-call (for npx-installed agents)
+scripts/gb-call                    ← canonical helper; Claude plugin invokes this
+.claude-plugin/                    ← plugin.json (manifest) + marketplace.json (listing)
 ```
 
 Skills are pure markdown. The helper is the only executable code in the plugin. This is intentional — the v0.2.0 commit (`daac766`) pivoted away from MCP to keep the surface that small.
+
+Each `skills/<name>/scripts/gb-call` is a **git symlink** pointing to `../../../scripts/gb-call`. When agents install via `npx skills install` (Cursor, Codex, etc.), the installer dereferences symlinks (`cp` with `dereference: true`) and writes a real file at the destination — the agent sees a plain executable and has no knowledge of the symlink. Edit only the canonical `scripts/gb-call`; the per-skill symlinks update automatically.
 
 ## The skill contract
 
@@ -70,8 +73,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 <one-paragraph intent: what this skill does and what it deliberately doesn't>
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`.
-It expects `GB_API_KEY` in env.
+All API calls go through the bundled helper. Under the Claude Code plugin install, it lives at `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call` (the plugin root). Under `npx skills install`, it lives at `scripts/gb-call` relative to this skill's directory. It expects `GB_API_KEY` in env.
 
 ## Workflow
 <numbered steps, with bash + JSON shown literally>

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Each skill's description names its trigger phrases and routes to sibling skills 
 
 ## How it works
 
-The plugin bundles a small Node helper (`scripts/gb-call`) that handles auth, base URL, and error reporting for every REST request. Skills call it via Bash:
+The plugin bundles a small Node helper (`scripts/gb-call`) that handles auth, base URL, and error reporting for every REST request. Each skill directory also contains a `scripts/gb-call` symlink so agents installed via `npx skills install` (Cursor, Codex, etc.) can resolve it relative to the skill directory. Skills call it via Bash:
 
 ```bash
 gb-call GET /api/v2/features
@@ -141,6 +141,9 @@ scripts/
   gb-call                              # Node REST helper (zero deps, Node 18+)
   README.md                            # gb-call usage, config sources, error catalog
 skills/
+  <name>/
+    SKILL.md                           # workflow + guardrails
+    scripts/gb-call                    # symlink → ../../scripts/gb-call (for npx-installed agents)
   gb-setup/SKILL.md                    # one-time onboarding
 
   # Revision lifecycle

--- a/skills/experiment-analyze/SKILL.md
+++ b/skills/experiment-analyze/SKILL.md
@@ -179,4 +179,5 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
 - `experiment-stop` — when the user is ready to act on a conclusive result.
 - `flag-targeting` — after stopping with a winner, the linked flag (if any) needs its `experiment-ref` rule updated or removed.
+- `experiment-brainstorm` — to ground ideas for the next test in results from past experiments.
 - `experiment-statistics` (when shipped) — for deeper questions about CUPED, sequential testing, multiple comparisons, dimensional analysis.

--- a/skills/experiment-analyze/scripts/gb-call
+++ b/skills/experiment-analyze/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/experiment-brainstorm/scripts/gb-call
+++ b/skills/experiment-brainstorm/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/experiment-design/scripts/gb-call
+++ b/skills/experiment-design/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/experiment-launch/SKILL.md
+++ b/skills/experiment-launch/SKILL.md
@@ -343,6 +343,7 @@ Print a summary:
 ## Handoffs
 
 - `experiment-design` — if no spec exists, route back here first.
+- `flag-search` — to find an existing flag ID when you only have a name or description.
 - `experiment-analyze` — after the experiment is running and traffic accumulates.
 - `experiment-stop` — when results are settled.
 - Manual metric creation — if a metric you need doesn't exist yet, the user must create it in the GrowthBook UI at `<host>/metrics` (or `<host>/fact-tables` for fact metrics) before re-running this skill. No skill for that yet.

--- a/skills/experiment-launch/scripts/gb-call
+++ b/skills/experiment-launch/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/experiment-stop/scripts/gb-call
+++ b/skills/experiment-stop/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-cleanup/scripts/gb-call
+++ b/skills/flag-cleanup/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-create/scripts/gb-call
+++ b/skills/flag-create/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-default-value/scripts/gb-call
+++ b/skills/flag-default-value/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-experiment/SKILL.md
+++ b/skills/flag-experiment/SKILL.md
@@ -91,6 +91,7 @@ The server allows patching `enabled`, `condition`, `savedGroups`, `prerequisites
 
 ## Handoffs
 
+- `flag-search` — to find a flag ID when you only have a name or description
 - `experiment-launch` — to create a new experiment and wire it to a flag end-to-end
 - `flag-targeting` — to edit the targeting conditions, scope, or saved groups on an existing experiment-ref rule
 - `flag-rules` — to reorder or delete experiment rules

--- a/skills/flag-experiment/scripts/gb-call
+++ b/skills/flag-experiment/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-graph/scripts/gb-call
+++ b/skills/flag-graph/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-metadata/scripts/gb-call
+++ b/skills/flag-metadata/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-monitoring/SKILL.md
+++ b/skills/flag-monitoring/SKILL.md
@@ -46,28 +46,31 @@ gb-call GET '/api/v1/metrics?datasourceId=<ds-id>'
 
 ```bash
 echo '{
+  "startActions": [
+    { "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0 } }
+  ],
   "steps": [
     {
       "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.05 } }]
+      "monitored": true,
+      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.1 } }]
     },
     {
       "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.25 } }]
-    },
-    {
-      "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 1.0 } }]
+      "monitored": true,
+      "holdConditions": { "requiresApproval": true },
+      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.5 } }]
     }
   ],
-  "endActions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 1.0 } }],
-  "startActions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": <pre-ramp-coverage> } }],
+  "endActions": [
+    { "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 1.0 } }
+  ],
   "monitoringConfig": {
     "datasourceId": "<ds-id>",
     "exposureQueryId": "<query-id>",
     "guardrailMetricIds": ["<metric-id>"],
     "signalMetricIds": ["<metric-id>"],
-    "autoUpdate": false,
+    "autoUpdate": true,
     "srmAction": "hold",
     "noTrafficAction": "warn",
     "noTrafficGracePeriodHours": 24,
@@ -76,7 +79,9 @@ echo '{
 }' | gb-call PUT /api/v2/features/<flag-id>/revisions/new/rules/<rule-id>/ramp-schedule -
 ```
 
-`autoUpdate: true` is the default — the system automatically rolls back on guardrail failure. Mention `autoUpdate: false` only if the user wants to control monitoring cadence manually or is concerned about query costs.
+`startActions` sets coverage to 0 (the rollback anchor). `monitored: true` on a step tells the ramp to wait for monitoring results before auto-advancing — it only has effect when `monitoringConfig` is present. The `holdConditions.requiresApproval` on step 2 adds a human gate after the interval elapses and monitoring clears.
+
+`autoUpdate: true` rolls back automatically on guardrail failure. Mention `autoUpdate: false` only if the user wants to control monitoring cadence manually or is concerned about query costs.
 
 Omit `startDate` unless the user explicitly requests a delayed start.
 

--- a/skills/flag-monitoring/SKILL.md
+++ b/skills/flag-monitoring/SKILL.md
@@ -142,7 +142,6 @@ For the full live ramp management action reference (pause, resume, complete, res
 - **`autoUpdate`** controls auto-rollback in the monitored ramp schedule's `monitoringConfig`. Defaults to `true` (rolls back automatically on guardrail failure).
 - **`startDate` is optional** — omit it unless the user explicitly wants a delayed start. Most teams start ramps via user action after verifying the publish succeeded.
 - **`cutoffDate` is niche** — don't mention it unless the user asks.
-- **Draft version threading.** If a version number is already in context from a previous write skill in this session, use it explicitly instead of `new`. Fall back to `new` when starting fresh.
 - **At least one guardrail metric is required.** Monitoring without a guardrail is just observation — if the user can't provide a guardrail metric, recommend using an unmonitored ramp (flag-ramp) instead.
 - **Metrics must be on the same datasource.** The `datasourceId` in `monitoringConfig` must match the datasource where the guardrail metrics are defined. If they're on different datasources, the API will reject the configuration.
 - **`autoUpdate: true` means the system rolls back without human approval.** Mention `autoUpdate: false` only if the user wants to control monitoring cadence manually or is concerned about query costs.

--- a/skills/flag-monitoring/scripts/gb-call
+++ b/skills/flag-monitoring/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-prerequisites/scripts/gb-call
+++ b/skills/flag-prerequisites/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-publish/scripts/gb-call
+++ b/skills/flag-publish/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-ramp/SKILL.md
+++ b/skills/flag-ramp/SKILL.md
@@ -52,31 +52,30 @@ See Path D for how to submit approvals via API once the interval has cleared.
 
 ```json
 {
+  "startActions": [
+    { "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0 } }
+  ],
   "steps": [
     {
       "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.05 } }]
+      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.1 } }]
     },
     {
       "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.25 } }]
-    },
-    {
-      "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.50 } }]
-    },
-    {
-      "interval": 86400,
-      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 1.0 } }]
+      "holdConditions": { "requiresApproval": true },
+      "actions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 0.5 } }]
     }
   ],
-  "endActions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 1.0 } }],
-  "startActions": [{ "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": <current-coverage> } }]
+  "endActions": [
+    { "targetType": "feature-rule", "targetId": "<rule-id>", "patch": { "coverage": 1.0 } }
+  ]
 }
 ```
 
+`startActions` = the state applied when the ramp begins and restored on rollback. Set this to the rule's **current coverage** before the ramp starts — typically 0 for a new rule.
 `endActions` = final state after all steps complete (typically 100% coverage).
-`startActions` = rollback state (the rule's coverage before the ramp started).
+
+To add guardrail metric monitoring to the ramp, add a `monitoringConfig` block and `"monitored": true` on each step — see `flag-monitoring`.
 
 Omit `startDate` and `cutoffDate` unless the user explicitly requests them — see Guardrails.
 
@@ -126,8 +125,8 @@ echo '{
         "actions": [{ "targetType": "feature-rule", "targetId": "new", "patch": { "coverage": 1.0 } }]
       }
     ],
-    "endActions": [{ "targetType": "feature-rule", "targetId": "new", "patch": { "coverage": 1.0 } }],
-    "startActions": [{ "targetType": "feature-rule", "targetId": "new", "patch": { "coverage": 0.0 } }]
+    "startActions": [{ "targetType": "feature-rule", "targetId": "new", "patch": { "coverage": 0.0 } }],
+    "endActions": [{ "targetType": "feature-rule", "targetId": "new", "patch": { "coverage": 1.0 } }]
   }
 }' | gb-call POST /api/v2/features/<flag-id>/revisions/new/rules -
 ```

--- a/skills/flag-ramp/scripts/gb-call
+++ b/skills/flag-ramp/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-review/scripts/gb-call
+++ b/skills/flag-review/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-revisions/scripts/gb-call
+++ b/skills/flag-revisions/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-rules/scripts/gb-call
+++ b/skills/flag-rules/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-schedule/scripts/gb-call
+++ b/skills/flag-schedule/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-search/scripts/gb-call
+++ b/skills/flag-search/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-targeting/SKILL.md
+++ b/skills/flag-targeting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flag-targeting
-description: Add, edit, or remove force-value or percentage-rollout rules on a GrowthBook feature flag, including conditions, saved groups, and rule-level prerequisites. Use when the user says "add a rule to flag Y", "release this flag to 10% of users", "turn this on for beta testers", "target US users", "add a condition to rule X", "edit the targeting condition on flag Z", "disable this rule", "remove the rule", "only for logged-in users", or "target users matching attribute Y". For environment kill switches (enable/disable the whole flag in an env), use flag-toggle. For experiment rules, use flag-experiment. For ramp schedules, use flag-ramp. For feature-level prerequisites, use flag-prerequisites.
+description: Add, edit, or remove force-value or percentage-rollout rules on a GrowthBook feature flag, including conditions, saved groups, and rule-level prerequisites. Use when the user says "add a rule to flag Y", "release this flag to 10% of users", "turn this on for beta testers", "target US users", "add a condition to rule X", "edit the targeting condition on flag Z", "disable this rule", "remove the rule", "only for logged-in users", or "target users matching attribute Y". For environment kill switches (enable/disable the whole flag in an env), use flag-toggle. For experiment rules, use flag-experiment. For ramp schedules, use flag-ramp. For monitored rollouts with guardrail metrics, use flag-monitoring. For feature-level prerequisites, use flag-prerequisites.
 allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 ---
 
@@ -325,6 +325,8 @@ Hand off to flag-publish. It handles:
 - `flag-toggle` — for environment-level enable/disable (kill switch)
 - `flag-rules` — for reordering rules or routing to other rule types
 - `flag-experiment` — for adding experiment-ref or inline experiment rules
+- `flag-ramp` — to progressively increase coverage on a rollout rule over time
+- `flag-monitoring` — to add guardrail metric monitoring to a rollout
 - `flag-prerequisites` — for feature-level prerequisite gates
 - `flag-search` — to resolve a flag ID from a description
 - `flag-publish` — to publish the draft (handles approval and merge conflicts)

--- a/skills/flag-targeting/scripts/gb-call
+++ b/skills/flag-targeting/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/flag-toggle/scripts/gb-call
+++ b/skills/flag-toggle/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call

--- a/skills/gb-setup/SKILL.md
+++ b/skills/gb-setup/SKILL.md
@@ -112,7 +112,7 @@ The API key is a Personal Access Token (PAT) tied to a GrowthBook user, so the A
    - What's in it (mask the API key — show only last 4).
    - That env vars take precedence over the file (so CI / one-off overrides keep working).
    - That re-running `/growthbook:setup` updates the file.
-   - The next thing they probably want: `/growthbook:flag-discovery` to see their flags, or `/growthbook:experiment-brainstorm` to look at past results.
+   - The next thing they probably want: `/growthbook:flag-search` to see their flags, or `/growthbook:experiment-brainstorm` to look at past results.
 
 ## Guardrails
 
@@ -145,6 +145,6 @@ Lines starting with `#` are comments. Blank lines are ignored. No quoting; value
 
 ## Handoffs
 
-- `flag-discovery` — natural first call after setup completes (no required inputs, exercises the new config).
+- `flag-search` — natural first call after setup completes (no required inputs, exercises the new config).
 - `experiment-brainstorm` — if the org already has stopped experiments, surfaces them immediately.
 - Any skill that emits a config-related error points back here.

--- a/skills/gb-setup/scripts/gb-call
+++ b/skills/gb-setup/scripts/gb-call
@@ -1,0 +1,1 @@
+../../../scripts/gb-call


### PR DESCRIPTION
## Context

Branched from main as an alternative approach to #5, which solves the same npx distribution problem by bundling 23 verbatim copies of `scripts/gb-call` into each skill directory.

## What this does differently

**Git symlinks instead of copies.** Each `skills/<name>/scripts/gb-call` is a symlink to `../../../scripts/gb-call` rather than a copy. The [vercel-labs/skills](https://github.com/vercel-labs/skills) installer uses `cp` with `dereference: true`, so agents installed via `npx skills install` receive a plain dereferenced file at the destination — no symlink knowledge required at runtime. Editing the canonical `scripts/gb-call` is sufficient going forward; no manual sync across 23 directories.

Git stores these as mode `120000` (symlink), not blobs, so the repo stays lean.

## Also included

Fixes to the `flag-ramp` and `flag-monitoring` example payloads:
- `startActions` now leads the payload and sets coverage to 0 (the rollback anchor), matching the realistic API shape
- Simplified to a 2-step example (0→0.1→0.5→1.0) with an approval gate on step 2
- `flag-monitoring` adds `monitored: true` on each step and clarifies its relationship to `monitoringConfig`
- `flag-ramp` keeps monitoring config out entirely, with a pointer to `flag-monitoring`

## Trade-offs vs #5

| | #5 (copies) | This PR (symlinks) |
|---|---|---|
| Repo size | +23 × 160 lines | +23 one-line symlink entries |
| Sync on `gb-call` edit | Manual copy to all 23 dirs | Nothing — symlinks auto-resolve |
| Windows (no Developer Mode) | Works | Git may not materialize symlinks; installer skips broken ones gracefully |
| Runtime behavior | Identical | Identical (installer dereferences) |

Windows is the one caveat — git on Windows without Developer Mode or `core.symlinks=true` checks out symlinks as text files, which the installer skips rather than failing. If Windows support is a hard requirement, #5 is safer. For macOS/Linux-first teams this approach is strictly better.