### PR TITLE
Fix setup skill slash command to /growthbook:gb-setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ When in doubt, check the existing skill that hits the closest endpoint. Don't mi
 
 ## Secret handling
 
-Two surfaces hold credentials: the env var or `~/.config/growthbook/.env` (PATs go in), and the conversation transcript (the user pastes a PAT into chat when running `/growthbook:setup`). Neither can be retroactively redacted.
+Two surfaces hold credentials: the env var or `~/.config/growthbook/.env` (PATs go in), and the conversation transcript (the user pastes a PAT into chat when running `/growthbook:gb-setup`). Neither can be retroactively redacted.
 
 Conventions every skill must follow:
 
@@ -166,7 +166,7 @@ Conventions every skill must follow:
 
 Two vars drive every skill: `GB_API_KEY` (required), `GB_API_URL` (self-hosted only). The PAT is tied to a GrowthBook user, so write skills let the API attribute new flags/experiments to the token's user — there is no separate owner var to set. `gb-call` reads them from `process.env` first, then falls back to `~/.config/growthbook/.env` if a var is unset. **Env always wins over the file** — useful for CI and one-off overrides.
 
-- Users get the file via `/growthbook:setup`, which validates against `GET /api/v1/projects` and writes with `chmod 600`.
+- Users get the file via `/growthbook:gb-setup`, which validates against `GET /api/v1/projects` and writes with `chmod 600`.
 - Skills never read or write the file themselves — only `gb-call` and `gb-setup` touch it. If you find yourself adding env-var-reading logic to another skill, stop: the helper handles it.
 - New env vars should be rare. Adding one means updating `gb-setup`, `gb-call`, the README, and every skill preamble. Prefer richer existing-var semantics (e.g. `GB_API_KEY` accepting both PATs and Secret Keys) over a new variable.
 
@@ -174,7 +174,7 @@ Two vars drive every skill: `GB_API_KEY` (required), `GB_API_URL` (self-hosted o
 
 Stays minimal on purpose. It is *one* Node file, *no* dependencies, uses built-in `fetch`. Reads env vars (with `.env` fallback), prints body to stdout on 2xx, prints a routing-aware error to stderr on non-2xx with exit 1.
 
-The error catalog is small but load-bearing — each branch in `explainHttpError` translates an HTTP failure into a one-line "here's what to do" hint (usually pointing at `/growthbook:setup`). When adding a new branch, keep two properties: (a) the synthesized message names a fix, not just a failure; (b) the raw response body is still printed underneath so power users can debug.
+The error catalog is small but load-bearing — each branch in `explainHttpError` translates an HTTP failure into a one-line "here's what to do" hint (usually pointing at `/growthbook:gb-setup`). When adding a new branch, keep two properties: (a) the synthesized message names a fix, not just a failure; (b) the raw response body is still printed underneath so power users can debug.
 
 Resist the urge to add features. `scripts/README.md` lists what is **not in scope**:
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This installs the skills at project scope. Restart your agent if the skills don'
 The quickest path is to run the setup skill:
 
 ```text
-/growthbook:setup
+/growthbook:gb-setup
 ```
 
 It walks you through your API key and (for self-hosted) your API URL — then validates against the live API and writes `~/.config/growthbook/.env` with `chmod 600`. Every other skill reads that file automatically.
@@ -106,14 +106,14 @@ Get a Personal Access Token from [`app.growthbook.io/account/personal-access-tok
 /growthbook:flag-search
 ```
 
-Should list your existing GrowthBook feature flags. If anything's wrong with the config, the error points back at `/growthbook:setup`.
+Should list your existing GrowthBook feature flags. If anything's wrong with the config, the error points back at `/growthbook:gb-setup`.
 
 ## How to invoke
 
 Skills can fire two ways:
 
 - **Automatically** when the agent detects an intent matching the skill's description ("create a feature flag for the new pricing page" → `flag-create`; "what should we test next" → `experiment-brainstorm`; "stop this experiment and ship the winner" → `experiment-stop`).
-- **Explicitly** by typing the slash command, e.g. `/growthbook:setup`, `/growthbook:flag-search`, `/growthbook:experiment-launch`.
+- **Explicitly** by typing the slash command, e.g. `/growthbook:gb-setup`, `/growthbook:flag-search`, `/growthbook:experiment-launch`.
 
 Each skill's description names its trigger phrases and routes to sibling skills when the request is a better fit elsewhere — so they compose cleanly when chained:
 
@@ -197,7 +197,7 @@ CHANGELOG.md
 
 - **Where the key lives.** `gb-setup` writes `~/.config/growthbook/.env` inside a `0700` directory at file mode `0600` — owner-read/write only. Environment variables take precedence over the file, so CI and one-off overrides keep working.
 - **Pasting a key into chat.** The value you give `gb-setup` lands in your local transcript and is sent to Anthropic as part of the conversation; it cannot be retroactively masked. Generate a fresh PAT for the plugin rather than reusing your personal admin token — that way you can revoke it independently if anything goes wrong.
-- **Revoking a leaked key.** Visit [`app.growthbook.io/account/personal-access-tokens`](https://app.growthbook.io/account/personal-access-tokens) (or your self-hosted equivalent) and revoke. Then re-run `/growthbook:setup` with the replacement.
+- **Revoking a leaked key.** Visit [`app.growthbook.io/account/personal-access-tokens`](https://app.growthbook.io/account/personal-access-tokens) (or your self-hosted equivalent) and revoke. Then re-run `/growthbook:gb-setup` with the replacement.
 - **What the helper rejects.** `gb-call` refuses values containing whitespace or control characters (CRLF in `GB_API_KEY` would inject headers); `gb-setup` refuses `http://` URLs and URLs with a path component.
 
 ## Contributing

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,7 +24,7 @@ gb-call <METHOD> <PATH> [BODY_FILE | -]
 `gb-call` reads config from two sources, in precedence order:
 
 1. **Process environment** — `GB_API_KEY`, `GB_API_URL`. Always wins. Useful for CI and one-off overrides.
-2. **`~/.config/growthbook/.env`** — same keys, `KEY=value` per line, no quoting. Written by `/growthbook:setup`. Only consulted when the corresponding env var is unset.
+2. **`~/.config/growthbook/.env`** — same keys, `KEY=value` per line, no quoting. Written by `/growthbook:gb-setup`. Only consulted when the corresponding env var is unset.
 
 | Var | Required | Default | Notes |
 | --- | --- | --- | --- |
@@ -43,15 +43,15 @@ gb-call <METHOD> <PATH> [BODY_FILE | -]
 
 | Condition | Stderr message routes user to |
 | --- | --- |
-| `GB_API_KEY` not set in env *and* not in `~/.config/growthbook/.env` | `/growthbook:setup` |
-| `401` / `403` from API | `/growthbook:setup` (key invalid, expired, or revoked) |
-| `404` on `api.growthbook.io` | `/growthbook:setup` (likely self-hosted, configure `GB_API_URL`) |
+| `GB_API_KEY` not set in env *and* not in `~/.config/growthbook/.env` | `/growthbook:gb-setup` |
+| `401` / `403` from API | `/growthbook:gb-setup` (key invalid, expired, or revoked) |
+| `404` on `api.growthbook.io` | `/growthbook:gb-setup` (likely self-hosted, configure `GB_API_URL`) |
 | `429` | rate-limit notice (60 rpm); retry after a moment |
 | Anything else | raw status + body |
 
 When adding a new error category, keep two properties intact:
 
-- **The message tells the user what to do**, not just what failed. If the fix is `/growthbook:setup`, name it.
+- **The message tells the user what to do**, not just what failed. If the fix is `/growthbook:gb-setup`, name it.
 - **The raw response body is still shown** below the synthesized hint, so power users can debug without re-running.
 
 ### Why this helper exists

--- a/skills/experiment-analyze/SKILL.md
+++ b/skills/experiment-analyze/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *) Bash(sleep *)
 
 Fetch results, refresh the snapshot only when the cached data is over 24 hours old or the user wants a different phase/dimension cut, then interpret. This skill is the heaviest in the catalog because of the conditional polling loop and the statistical interpretation — slow down and do each step deliberately.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`. The skill also uses `sleep` between poll calls.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If unset or invalid, gb-call's error message points back at `/growthbook:gb-setup`. The skill also uses `sleep` between poll calls.
 
 ## Workflow
 

--- a/skills/experiment-brainstorm/SKILL.md
+++ b/skills/experiment-brainstorm/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Propose new experiment ideas grounded in the team's past stopped experiments. Read history first; propose based on what actually moved metrics, where guardrails failed, and which tags or projects under-explored.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If unset or invalid, gb-call's error message points back at `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/experiment-design/SKILL.md
+++ b/skills/experiment-design/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Help the user produce an experiment spec that's actually launchable. Walk them through hypothesis, variations, metrics, and sample-size sanity. This skill does **not** write to GrowthBook — it ends with a ready-to-launch spec that `experiment-launch` consumes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If unset or invalid, gb-call's error message points back at `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/experiment-launch/SKILL.md
+++ b/skills/experiment-launch/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Launch a GrowthBook A/B test end-to-end: create the experiment in draft, prep or reuse the feature flag, add the experiment-ref rule on a fresh draft revision, then call `/start` to publish the rule and flip the experiment to running. Handles the approval-required and pre-launch-checklist failure paths.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:gb-setup`.
 
 ## Required inputs
 

--- a/skills/experiment-stop/SKILL.md
+++ b/skills/experiment-stop/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Stop a running experiment, optionally declaring a winning variation and ramping it to all eligible traffic via a temporary rollout. The endpoint is `POST /api/v1/experiments/<id>/stop` (a dedicated endpoint, not the generic update). All variation references are **variation ID strings** like `var_abc123`, not 0-based integer indexes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If unset or invalid, gb-call's error message points back at `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-cleanup/SKILL.md
+++ b/skills/flag-cleanup/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Archive or delete a stale feature flag. Two paths: **archive** (reversible, soft-disable) or **delete** (permanent; always goes through archive first as a safety gate). The skill coordinates code-cleanup with the agent's general Read/Edit tools, surfacing call sites from GrowthBook's Code References API (when configured) or falling back to Grep against the user's current directory.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If unset or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If unset or invalid, gb-call's error message points back at `/growthbook:gb-setup`.
 
 ## Required inputs
 

--- a/skills/flag-create/SKILL.md
+++ b/skills/flag-create/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Create a new feature flag in GrowthBook. We always set `{enabled: false}` for every environment explicitly in the payload, so the flag ships disabled regardless of the org's default-state-for-new-environments setting — the user must enable it after creation. Feature keys are permanent; pick the name carefully.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` — set in your shell, or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`. If it's missing or invalid, gb-call's error message points back at `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-default-value/SKILL.md
+++ b/skills/flag-default-value/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Set the default value of a GrowthBook feature flag. The default value is what the SDK returns when no rules match a user — it's the flag's baseline state, not a targeting rule. Changes go through a draft revision and require publishing before they take effect.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Required inputs
 

--- a/skills/flag-experiment/SKILL.md
+++ b/skills/flag-experiment/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Add an `experiment-ref` rule to a GrowthBook feature flag. This links a flag rule to a separately-managed GrowthBook experiment object — the experiment is the source of truth for variations, metrics, and analysis.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-graph/SKILL.md
+++ b/skills/flag-graph/SKILL.md
@@ -10,7 +10,7 @@ Trace the dependency relationships around a GrowthBook feature flag. Use this sk
 
 Read-only — this skill never writes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-metadata/SKILL.md
+++ b/skills/flag-metadata/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Update the administrative metadata of an existing GrowthBook feature flag. Metadata changes (description, owner, project, tags, custom fields, JSON schema) go through a draft revision like all other flag changes — they need to be published before they take effect.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Required inputs
 

--- a/skills/flag-monitoring/SKILL.md
+++ b/skills/flag-monitoring/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *), Bash(open https://
 
 Set up and manage a monitored progressive rollout (also called a "safe rollout") for a GrowthBook feature flag. A safe rollout is a standard `rollout` rule with a multi-step ramp schedule and `monitoringConfig` attached — the monitoring watches guardrail metrics at each step and can signal or automatically trigger a rollback if regressions are detected.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Required inputs for monitoring configuration
 

--- a/skills/flag-prerequisites/SKILL.md
+++ b/skills/flag-prerequisites/SKILL.md
@@ -12,7 +12,7 @@ Add, remove, or inspect feature-level prerequisites on a GrowthBook feature flag
 
 This is distinct from rule-level prerequisites (which gate a single rule and support richer conditions) — feature-level prerequisites apply to every rule on the flag simultaneously.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-publish/SKILL.md
+++ b/skills/flag-publish/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *), Bash(open https://
 
 Get a GrowthBook feature flag draft revision live, or undo a change. Handles the full publish flow including the two common failure modes — approval-required (blocked) and merge conflict (stale base) — and the escape hatches: discard and revert.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-ramp/SKILL.md
+++ b/skills/flag-ramp/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *), Bash(open https://
 
 Create and manage multi-step ramp schedules for a GrowthBook feature flag rule. A ramp schedule progressively increases (or decreases) a rule's traffic coverage over time, with defined hold intervals between steps. Steps can be manual (operator advances them) or time-gated (auto-advance after an interval).
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## How ramp schedules work
 

--- a/skills/flag-review/SKILL.md
+++ b/skills/flag-review/SKILL.md
@@ -10,7 +10,7 @@ Request and submit approval reviews on GrowthBook feature flag draft revisions. 
 
 Two roles use this skill: the **drafter** (requests a review, can't self-approve) and the **reviewer** (submits the review decision).
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Approval flow
 

--- a/skills/flag-revisions/SKILL.md
+++ b/skills/flag-revisions/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Inspect and manage draft revisions on GrowthBook feature flags. Every flag change goes through a draft revision before going live — this is the "what's in flight?" skill. Use it to see open drafts, understand their status, and manage their lifecycle (create, discard). Making actual flag changes (rules, metadata, toggles, default value) is handled by the relevant flag-* write skills, which create and manage drafts automatically.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Revision status reference
 

--- a/skills/flag-rules/SKILL.md
+++ b/skills/flag-rules/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/gb-call *)
 
 Entry point for rule operations on a GrowthBook feature flag. Use this skill to inspect rules, delete a rule, or reorder rules. For creating or editing rules, this skill identifies the right rule type and routes to the specialized skill.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Rule types reference
 

--- a/skills/flag-schedule/SKILL.md
+++ b/skills/flag-schedule/SKILL.md
@@ -10,7 +10,7 @@ Add a timed activation window to a GrowthBook feature flag rule. A scheduled rul
 
 Scheduling applies to `force` and `rollout` rule types. It does not apply to `experiment-ref` or `safe-rollout` rules.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## How scheduling works
 

--- a/skills/flag-search/SKILL.md
+++ b/skills/flag-search/SKILL.md
@@ -10,7 +10,7 @@ Search, list, and audit GrowthBook feature flags. Three jobs share this skill: b
 
 Read-only — this skill never writes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Workflow
 

--- a/skills/flag-targeting/SKILL.md
+++ b/skills/flag-targeting/SKILL.md
@@ -10,7 +10,7 @@ Add, edit, or remove targeting rules on an existing GrowthBook feature flag. Han
 
 Every change goes through a draft revision and requires publishing. For publishing, use flag-publish — it handles approval-required and merge-conflict failure modes.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Required inputs
 

--- a/skills/flag-toggle/SKILL.md
+++ b/skills/flag-toggle/SKILL.md
@@ -10,7 +10,7 @@ Enable or disable a GrowthBook feature flag in a specific environment. Toggling 
 
 Like all flag changes, environment toggles go through the draft → review → publish flow. There is no bypass path — review is the happy path, not an obstacle.
 
-All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:setup`.
+All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-call`. It needs `GB_API_KEY` set in env or written to `~/.config/growthbook/.env` by `/growthbook:gb-setup`.
 
 ## Required inputs
 

--- a/skills/gb-setup/SKILL.md
+++ b/skills/gb-setup/SKILL.md
@@ -111,7 +111,7 @@ The API key is a Personal Access Token (PAT) tied to a GrowthBook user, so the A
    - Where the file is (`~/.config/growthbook/.env`).
    - What's in it (mask the API key — show only last 4).
    - That env vars take precedence over the file (so CI / one-off overrides keep working).
-   - That re-running `/growthbook:setup` updates the file.
+   - That re-running `/growthbook:gb-setup` updates the file.
    - The next thing they probably want: `/growthbook:flag-search` to see their flags, or `/growthbook:experiment-brainstorm` to look at past results.
 
 ## Guardrails


### PR DESCRIPTION
The setup skill's canonical name is gb-setup (its directory and frontmatter name), so the working slash command is /growthbook:gb-setup. The docs invoked it as /growthbook:setup in every runnable example and error-pointer, which doesn't resolve.

Correct all references across README, CLAUDE.md, scripts/README.md, and every skill preamble.