### PR TITLE
Use new experiment list filtering/sorting params in experiment skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `growthbook` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Experiment skills now use the new filtering/sorting params on `GET /api/v1/experiments` (requires a GrowthBook release that includes them):
+  - `experiment-brainstorm` pulls history newest-first via `sortBy=dateCreated&sortOrder=desc` (previously the API's fixed oldest-first order silently grounded proposals in the oldest experiments on multi-page orgs), and scopes pulls with `tag` / `projectId` / `owner` when the user narrows the ask. Corrected the page-size claim: `limit` caps at 100, not 50.
+  - `experiment-analyze` and `experiment-stop` gain a resolve-by-name entry point (`?q=<text>`, matching name / tracking key / description / hypothesis) for when the user doesn't have the experiment ID, plus a guardrail documenting that `q` rejects negation and comparison operators with a 400.
+
 ## [1.1.0] — 2026-06-01
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to the `growthbook` plugin are documented here. Format follo
 ## [Unreleased]
 
 ### Changed
-- Experiment skills now use the new filtering/sorting params on `GET /api/v1/experiments` (requires a GrowthBook release that includes them):
-  - `experiment-brainstorm` pulls history newest-first via `sortBy=dateCreated&sortOrder=desc` (previously the API's fixed oldest-first order silently grounded proposals in the oldest experiments on multi-page orgs), and scopes pulls with `tag` / `projectId` / `owner` when the user narrows the ask. Corrected the page-size claim: `limit` caps at 100, not 50.
+- Experiment skills now use the filtering/sorting params added to `GET /api/v1/experiments` in [growthbook#6418](https://github.com/growthbook/growthbook/pull/6418) — `q`, `owner`, `result`, `tag`, `implementationType`, `metricId`, `bandits`, `archived`, `sortBy`, `sortOrder` (on Cloud now; self-hosted needs a release later than v5.0.0):
+  - `experiment-brainstorm` pulls history newest-first via `sortBy=dateCreated&sortOrder=desc` (previously the API's fixed oldest-first order silently grounded proposals in the oldest experiments on multi-page orgs), and scopes pulls with `tag` / `projectId` / `owner` / `result` / `metricId` / `implementationType` when the user narrows the ask, plus optional `bandits=false` so per-arm bandit results don't distort the win-rate tally. Corrected the page-size claim: `limit` caps at 100, not 50.
   - `experiment-analyze` and `experiment-stop` gain a resolve-by-name entry point (`?q=<text>`, matching name / tracking key / description / hypothesis) for when the user doesn't have the experiment ID, plus a guardrail documenting that `q` rejects negation and comparison operators with a 400.
+  - Guardrails for two naming traps the endpoint's shape invites: `result` is the *recorded* result and is retained if a stopped experiment is restarted (so `result=won` can return running experiments — keep `status=stopped`), and bandits are filtered with `bandits`, not `type` (there is no `type` list param; `implementationType` filters the linked-change kind instead, a different axis from the response's `type` field).
 
 ## [1.1.0] — 2026-06-01
 

--- a/skills/experiment-analyze/SKILL.md
+++ b/skills/experiment-analyze/SKILL.md
@@ -177,6 +177,7 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 - **Rate limit awareness.** Happy path is a single `/results` call. Worst case (no snapshot or stale + 60-iteration poll + re-fetch) is ~63 calls spread over 5 minutes (~13/min), well under 60 rpm. If multiple users invoke this concurrently in the same org the limit can still bite — surface clearly if `gb-call` returns a 429.
 - **Read-only.** This skill never stops or modifies the experiment. Hand off to `experiment-stop` when the user wants to act.
 - **`q` rejects negation and operators with a 400.** The list endpoint's `q` param takes the app's search syntax (`status:running tag:checkout` plus free text) but hard-rejects `!`, `~`, `^`, `>`, `<`, `=`. Send plain `field:value` tokens and free text only.
+- **When resolving by name, filter bandits with `bandits`, not `type`.** The response's `type` field (`standard` / `multi-armed-bandit`) is not a list query param; sending `type=` returns a 400. Use `bandits=false` to exclude bandits from the candidates, since this skill halts on them anyway. (`implementationType` is a different axis — the linked-change kind.)
 
 ## Endpoints used
 

--- a/skills/experiment-analyze/SKILL.md
+++ b/skills/experiment-analyze/SKILL.md
@@ -14,6 +14,14 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
 1. **Fetch results + experiment metadata in one call.** `/results` returns `{ experiment, result }` — the same payload that powers the GrowthBook UI's results view, so there's no need for a separate metadata call.
 
+   If the user gave a name instead of an ID ("the checkout test"), resolve it first — `q` matches against name, tracking key, description, and hypothesis:
+
+   ```bash
+   gb-call GET '/api/v1/experiments?q=checkout&sortBy=dateUpdated&sortOrder=desc&limit=10'
+   ```
+
+   If more than one experiment plausibly matches, list the candidates and let the user pick — don't guess.
+
    ```bash
    gb-call GET /api/v1/experiments/<experiment-id>/results
    # or, when the user asks for a specific phase / dimension cut:
@@ -168,9 +176,11 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 - **24h is a deliberate ceiling, not the auto-refresh cadence.** The server auto-refreshes every 6h by default, so a snapshot under 24h has almost always been refreshed at least once. The skill's 24h bar gives the user a useful conservative window without paying snapshot compute on data that hasn't moved. Don't drop it to "any data older than a minute" — that's how you pin a busy org against the 60 rpm limit.
 - **Rate limit awareness.** Happy path is a single `/results` call. Worst case (no snapshot or stale + 60-iteration poll + re-fetch) is ~63 calls spread over 5 minutes (~13/min), well under 60 rpm. If multiple users invoke this concurrently in the same org the limit can still bite — surface clearly if `gb-call` returns a 429.
 - **Read-only.** This skill never stops or modifies the experiment. Hand off to `experiment-stop` when the user wants to act.
+- **`q` rejects negation and operators with a 400.** The list endpoint's `q` param takes the app's search syntax (`status:running tag:checkout` plus free text) but hard-rejects `!`, `~`, `^`, `>`, `<`, `=`. Send plain `field:value` tokens and free text only.
 
 ## Endpoints used
 
+- `GET /api/v1/experiments?q=<text>` — resolve an experiment ID when the user only gave a name or keyword. `q` matches name, tracking key, description, and hypothesis; pair with `sortBy=dateUpdated&sortOrder=desc` so active experiments surface first.
 - `GET /api/v1/experiments/<id>/results` — primary entry point; returns `{ experiment, result }` so step 1 grabs metadata, status, and the snapshot timestamp (`result.dateUpdated`) in a single call. Accepts `phase` / `dimension` query params.
 - `POST /api/v1/experiments/<id>/snapshot` — trigger a fresh snapshot when results are over 24h old or the user wants a phase/dimension cut the cached snapshot doesn't cover. Body accepts `phase` (integer) and `dimension` (string).
 - `GET /api/v1/snapshots/<snapshot-id>` — poll for snapshot completion (5s interval, 60 iteration cap). Returns `{ snapshot: { id, experiment, status } }`.

--- a/skills/experiment-brainstorm/SKILL.md
+++ b/skills/experiment-brainstorm/SKILL.md
@@ -15,10 +15,12 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 1. **Pull the experiment list, most recent first.**
 
    ```bash
-   gb-call GET '/api/v1/experiments?limit=50&status=stopped'
+   gb-call GET '/api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc'
    ```
 
-   Returns up to 50 experiments per page (the API cap).
+   Returns up to 50 experiments per page (`limit` caps at 100). Keep `sortBy=dateCreated&sortOrder=desc` — the API's default order is oldest-first, and on an org with more than one page of history an unsorted pull grounds every proposal in ancient experiments.
+
+   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: `&tag=checkout`, `&projectId=prj_abc123`, or `&owner=<email>`. Filter params take comma-separated values (ORed within a param; separate params AND together).
 
 2. **Fetch results for each stopped experiment.** Loop over the stopped IDs:
 
@@ -65,7 +67,7 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
 ## Endpoints used
 
-- `GET /api/v1/experiments?limit=50&status=stopped` — list experiments (returns metadata including status). Cap is 50 per page.
+- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag`, `projectId`, `owner` (comma-separated values ORed within a param).
 - `GET /api/v1/experiments/{id}/results` — full results for one experiment. One call per stopped experiment in scope.
 
 ## Output template

--- a/skills/experiment-brainstorm/SKILL.md
+++ b/skills/experiment-brainstorm/SKILL.md
@@ -20,7 +20,7 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
    Returns up to 50 experiments per page (`limit` caps at 100). Keep `sortBy=dateCreated&sortOrder=desc` — the API's default order is oldest-first, and on an org with more than one page of history an unsorted pull grounds every proposal in ancient experiments.
 
-   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: `&tag=checkout`, `&projectId=prj_abc123`, or `&owner=<email>`. Filter params take comma-separated values (ORed within a param; separate params AND together).
+   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: `&tag=checkout`, `&projectId=prj_abc123`, or `&owner=<email>`. `tag` and `owner` take comma-separated values (ORed within a param); `projectId` takes a single project id. Separate params AND together.
 
 2. **Fetch results for each stopped experiment.** Loop over the stopped IDs:
 
@@ -67,7 +67,7 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
 ## Endpoints used
 
-- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag`, `projectId`, `owner` (comma-separated values ORed within a param).
+- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag` and `owner` (comma-separated values ORed within a param), `projectId` (single project id).
 - `GET /api/v1/experiments/{id}/results` — full results for one experiment. One call per stopped experiment in scope.
 
 ## Output template

--- a/skills/experiment-brainstorm/SKILL.md
+++ b/skills/experiment-brainstorm/SKILL.md
@@ -20,7 +20,9 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
    Returns up to 50 experiments per page (`limit` caps at 100). Keep `sortBy=dateCreated&sortOrder=desc` — the API's default order is oldest-first, and on an org with more than one page of history an unsorted pull grounds every proposal in ancient experiments.
 
-   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: `&tag=checkout`, `&projectId=prj_abc123`, or `&owner=<email>`. `tag` and `owner` take comma-separated values (ORed within a param); `projectId` takes a single project id. Separate params AND together.
+   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: `&tag=checkout`, `&projectId=prj_abc123`, `&owner=<email>`, `&result=won,lost`, `&metricId=met_abc123`, or `&implementationType=feature`. `tag`, `owner`, `result`, `metricId`, and `implementationType` take comma-separated values (ORed within a param); `projectId` takes a single project id. Separate params AND together.
+
+   Consider adding `&bandits=false` when the user wants product-test patterns: bandit results carry per-arm probabilities rather than a winner/loser verdict, so they distort the win-rate tally in step 4.
 
 2. **Fetch results for each stopped experiment.** Loop over the stopped IDs:
 
@@ -57,6 +59,8 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 ## Guardrails
 
 - **Stopped experiments only.** Filter drafts and running experiments out of your synthesis. If the user asks about the live pipeline, that's a different question — point them at `flag-discovery` or `experiment-design` instead.
+- **`result` alone does not imply stopped.** A result is recorded when an experiment is stopped but is retained if it's later restarted, so `result=won` can return running experiments. Always keep `status=stopped` in the query rather than relying on `result` to scope the history.
+- **Filtering bandits uses `bandits`, not `type`.** The list endpoint has no `type` param — `implementationType` filters the linked-change kind (`feature` / `visualChange` / `redirect`), which is a different axis from the response's `type` field (`standard` / `multi-armed-bandit`). Sending `type=` returns a 400.
 - **Ground every proposal.** Cite the specific past experiment(s) you're building on. No proposals based on generic best practices.
 - **Don't repeat losers without saying why.** If a proposal mirrors a recent loser, say so explicitly and explain what's different this time.
 - **Win rate definition:** `won / (won + lost + inconclusive)`. Don't invent another formula.
@@ -67,7 +71,7 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 
 ## Endpoints used
 
-- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag` and `owner` (comma-separated values ORed within a param), `projectId` (single project id).
+- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag`, `owner`, `result`, `metricId`, `implementationType` (comma-separated values ORed within a param), `projectId` (single project id), `bandits` (`true`/`false`), `archived`. Sortable fields: `dateCreated`, `dateUpdated`, `name`.
 - `GET /api/v1/experiments/{id}/results` — full results for one experiment. One call per stopped experiment in scope.
 
 ## Output template

--- a/skills/experiment-stop/SKILL.md
+++ b/skills/experiment-stop/SKILL.md
@@ -135,6 +135,7 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 - **`analysis` should explain the decision in plain English (markdown).** Future readers (including future-self) will want context. Don't leave it blank when declaring a winner.
 - **Run `experiment-analyze` first if the user hasn't.** Stopping based on a glance at the dashboard is a common mistake — interim numbers can flip, and the data-quality checks in `experiment-analyze` can flag results that look conclusive but aren't.
 - **`q` rejects negation and operators with a 400.** The list endpoint's `q` param takes the app's search syntax (`status:running tag:checkout` plus free text) but hard-rejects `!`, `~`, `^`, `>`, `<`, `=`. Send plain `field:value` tokens and free text only.
+- **When resolving by name, filter bandits with `bandits`, not `type`.** The response's `type` field (`standard` / `multi-armed-bandit`) is not a list query param; sending `type=` returns a 400. Add `bandits=false` to keep bandits out of the candidate list, since this skill halts on them anyway. (`implementationType` is a different axis — the linked-change kind.)
 
 ## Endpoints used
 

--- a/skills/experiment-stop/SKILL.md
+++ b/skills/experiment-stop/SKILL.md
@@ -18,6 +18,14 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
    gb-call GET /api/v1/experiments/<experiment-id>
    ```
 
+   If the user gave a name instead of an ID ("stop the checkout test"), resolve it first — `q` matches against name, tracking key, description, and hypothesis, and `status=running` keeps the candidates to experiments this skill can act on:
+
+   ```bash
+   gb-call GET '/api/v1/experiments?q=checkout&status=running'
+   ```
+
+   If more than one experiment plausibly matches, list the candidates and let the user pick — don't guess. Stopping the wrong experiment is not cleanly reversible.
+
    Check the `status` field. Only `running` experiments should be stopped via this skill. If `status === "draft"`, the experiment hasn't started — the user wants to delete it, not stop it (different operation). If `status === "stopped"`, it's already done.
 
    Also capture the `type` field. If `type === "multi-armed-bandit"`, halt and tell the user this skill targets standard A/B tests; bandits have their own lifecycle (stop is similar but interpretation and rollout differ — recommend they review in the UI before scripting).
@@ -126,9 +134,11 @@ All API calls go through the bundled helper: `${CLAUDE_PLUGIN_ROOT}/scripts/gb-c
 - **Always remind about the linked flag.** Stopping the experiment does not remove the `experiment-ref` rule from the linked flag. Without a temporary rollout, the flag keeps routing to a stale experiment until the user cleans the rule up.
 - **`analysis` should explain the decision in plain English (markdown).** Future readers (including future-self) will want context. Don't leave it blank when declaring a winner.
 - **Run `experiment-analyze` first if the user hasn't.** Stopping based on a glance at the dashboard is a common mistake — interim numbers can flip, and the data-quality checks in `experiment-analyze` can flag results that look conclusive but aren't.
+- **`q` rejects negation and operators with a 400.** The list endpoint's `q` param takes the app's search syntax (`status:running tag:checkout` plus free text) but hard-rejects `!`, `~`, `^`, `>`, `<`, `=`. Send plain `field:value` tokens and free text only.
 
 ## Endpoints used
 
+- `GET /api/v1/experiments?q=<text>&status=running` — resolve an experiment ID when the user only gave a name or keyword. `q` matches name, tracking key, description, and hypothesis.
 - `GET /api/v1/experiments/<id>` — fetch state, variations, and `type`
 - `POST /api/v1/experiments/<id>/stop` — stop and optionally declare a winner + temporary rollout
 - `POST /api/v1/experiments/<id>/modify-temporary-rollout` — toggle the temporary rollout off (or on) after stopping, without re-running this skill


### PR DESCRIPTION
## What

Updates the experiment skills for the query params added to `GET /api/v1/experiments` in [growthbook#6418](https://github.com/growthbook/growthbook/pull/6418) (**merged**): `q`, `owner`, `result`, `tag`, `implementationType`, `metricId`, `bandits`, `archived`, `sortBy`, `sortOrder`.

- **experiment-brainstorm** — pulls history newest-first via `sortBy=dateCreated&sortOrder=desc`. This fixes real drift: step 1 already said "most recent first," but the API's fixed sort order was oldest-first, so on orgs with more than one page of history the skill grounded every proposal in the oldest experiments. Also scopes pulls with `tag` / `projectId` / `owner` / `result` / `metricId` / `implementationType` when the user narrows the ask, offers `bandits=false` so per-arm bandit results don't distort the win-rate tally, and corrects the page-size claim (`limit` caps at 100, not 50).
- **experiment-analyze / experiment-stop** — add a resolve-by-name entry point (`?q=<text>`, matching name / tracking key / description / hypothesis) for when the user gives a name instead of an experiment id, mirroring how the flag skills hand off to `flag-search`.
- **Guardrails** for the traps this endpoint's shape invites:
  - `q` rejects negation (`!`) and comparison operators with a 400.
  - `result` is the *recorded* result and is retained if a stopped experiment is restarted, so `result=won` can return running experiments — keep `status=stopped` rather than relying on `result` to scope history.
  - Bandits filter via `bandits`, not `type`. There is no `type` list param (sending one is a 400); `implementationType` filters the linked-change kind, a different axis from the response's `type` field.
- **CHANGELOG** — Unreleased entry.

The trackingKey-based list calls in `flag-cleanup` and `flag-graph` are unaffected and left alone. Sibling of #15 (features/`flag-search`), which gates on a different API PR.

## Release gating — why this is still a draft

The params are **merged to `main`** but not in a tagged release: the latest is `v5.0.0` (2026-07-20) and #6418 merged 2026-07-28. So GrowthBook Cloud has them today, while self-hosted users on v5.0.0 or earlier would get a 400 (the list endpoint's query schema is strict).

Ready to merge as soon as a release includes #6418 — or sooner, if we're comfortable with self-hosted users on older versions seeing 400s from these skills.

## Verification

Per CLAUDE.md, claims were verified against the merged source of truth on `main` — the Zod validator (`listExperimentsValidator` in `packages/shared/src/validators/experiments.ts`) and the handler (`packages/back-end/src/api/experiments/listExperiments.ts`): sortable fields are `dateCreated` / `dateUpdated` / `name` (default `dateCreated` ascending, which confirms the oldest-first behavior noted above), `limit` max is 100, `q` free text matches name/trackingKey/description/hypothesis with strict parsing that 400s on negation/operators, CSV params are `owner` / `result` / `tag` / `implementationType` / `metricId` while `projectId` is a single exact id, and `name` sorting is case-insensitive (sorted in the handler via `localeCompare`, not in Mongo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)