### PR TITLE
flag-search: use new v2 features list filters and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `growthbook` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- `flag-search` now uses the new filtering/sorting params on `GET /api/v2/features` (requires a GrowthBook release that includes them): `owner` (userId or email), `valueType`, `baseConfig` (find Config-mode flags backed by a config key), `archived`, comma-separated `tag` values, and `sortBy`/`sortOrder`. Searches that previously fetched every page and filtered client-side ("flags owned by X", "boolean flags") are now single filtered calls; only environment state and rule shape still need client-side filtering. Also fixes drift: the skill documented a `?tag=` filter that the strict v2 query schema rejected with a 400 before these params existed.
+
 ## [1.1.0] — 2026-06-01
 
 ### Removed

--- a/skills/flag-search/SKILL.md
+++ b/skills/flag-search/SKILL.md
@@ -39,30 +39,33 @@ Group output by project if the org uses projects. Flag keys that look like orpha
 
 ### Path B — Search by criteria
 
-Use the `/api/v2/features` list endpoint with query params to narrow results. Available filters:
+Use the `/api/v2/features` list endpoint with query params to narrow results. `tag`, `owner`, and `valueType` take comma-separated values (ORed within a param; separate params AND together), and `sortBy`/`sortOrder` control ordering:
 
 ```bash
-# By project:
-gb-call GET '/api/v2/features?projectId=<project-id>'
+# By project + tags:
+gb-call GET '/api/v2/features?projectId=<project-id>&tag=payments,checkout'
 
-# By tag (exact match, single tag):
-gb-call GET '/api/v2/features?tag=<tag>'
+# By owner, most recently updated first:
+gb-call GET '/api/v2/features?owner=bryce@company.com&sortBy=dateUpdated&sortOrder=desc'
 ```
 
-For filters not supported by the API (owner, environment state, value type), fetch the full set and filter client-side from the response fields.
+Only environment state and rule shape have no API filter — for those, fetch the (param-narrowed) set and filter client-side from the response fields.
 
 Common searches:
 
 | Request | Approach |
 | --- | --- |
-| "Flags owned by X" | Fetch all, filter on `owner.email` |
-| "Boolean flags" | Fetch all, filter on `valueType === "boolean"` |
-| "Flags enabled in production" | Fetch all, filter on `environmentSettings.production.enabled === true` |
-| "Flags with no rules" | Fetch all, filter on `rules.length === 0` |
+| "Flags owned by X" | `GET /api/v2/features?owner=<email or u_...>` |
+| "Boolean flags" | `GET /api/v2/features?valueType=boolean` |
 | "Flags tagged payments" | `GET /api/v2/features?tag=payments` |
 | "Flags in project Y" | Resolve project name → ID, then `GET /api/v2/features?projectId=<id>` |
+| "Recently changed flags" | `GET /api/v2/features?sortBy=dateUpdated&sortOrder=desc` |
+| "Flags backed by config X" | `GET /api/v2/features?baseConfig=<config-key>` |
+| "Archived flags too" | Add `archived=true` (default excludes archived) |
+| "Flags enabled in production" | Fetch (narrowed) set, filter on `environmentSettings.production.enabled === true` |
+| "Flags with no rules" | Fetch (narrowed) set, filter on `rules.length === 0` |
 
-When filtering client-side on a large org, paginate through the full set first, then filter.
+When a search needs client-side filtering on a large org, narrow with API params first, then paginate through the remainder.
 
 ### Path C — Stale flag audit ("what can we clean up?")
 
@@ -118,14 +121,16 @@ Do not delete anything. Hand off to flag-cleanup for actual removal.
 - **`/feature-keys` is unpaginated; `/features` is paginated (100/page).** Use `/feature-keys` for full ID inventory; `/features` for detail queries.
 - **`neverStale: true` flags are excluded from cleanup recommendations.** They appear as `staleReason: "never-stale"` — surface them separately but never suggest removing them.
 - **Don't infer staleness yourself.** Use `/stale-features` for the canonical determination; it encodes GrowthBook's own rules and surfaces replacement values you can't compute locally.
-- **Client-side filters on large orgs can be slow.** Rate limit is 60 rpm. If paginating through hundreds of flags, surface progress updates.
+- **Owner filter values are userIds or emails.** Emails are resolved to the matching org member; legacy flags that store a raw display name as their owner only match that exact string.
+- **"Config" is not a `valueType`.** Config-backed flags are JSON flags (`valueType: "json"`) with a `baseConfig` key — filter them with `baseConfig=<config-key>`, not `valueType=config` (which returns a 400).
+- **Client-side filters on large orgs can be slow.** Rate limit is 60 rpm. Narrow with API params (`tag`, `owner`, `valueType`, `projectId`) before paginating; if still paginating through hundreds of flags, surface progress updates.
 - **v2 rules are flat.** Under v2, the `rules` array is top-level on the flag object with `allEnvironments`/`environments` scope per rule — not nested under each environment as in v1.
 - **Read-only.** Never POST, PUT, PATCH, or DELETE from this skill. Route to flag-cleanup for removals.
 
 ## Endpoints used
 
 - `GET /api/v2/feature-keys` — full ID list, no pagination cap
-- `GET /api/v2/features` — paginated list with full configuration (`limit`, `offset`, `projectId`, `tag` filters)
+- `GET /api/v2/features` — paginated list with full configuration. Filters: `projectId`, `tag`, `owner`, `valueType`, `baseConfig`, `archived`, `clientKey` (CSV values ORed within `tag`/`owner`/`valueType`); sorting: `sortBy` (`id`, `dateCreated`, `dateUpdated`) + `sortOrder`
 - `GET /api/v2/features/:id` — full configuration for one flag
 - `GET /api/v2/stale-features?ids=a,b,c` — staleness audit (requires explicit `ids`)
 - `GET /api/v1/projects` — resolve project name to ID for project-scoped searches

--- a/skills/flag-search/SKILL.md
+++ b/skills/flag-search/SKILL.md
@@ -49,7 +49,7 @@ gb-call GET '/api/v2/features?projectId=<project-id>&tag=payments,checkout'
 gb-call GET '/api/v2/features?owner=bryce@company.com&sortBy=dateUpdated&sortOrder=desc'
 ```
 
-Only environment state and rule shape have no API filter — for those, fetch the (param-narrowed) set and filter client-side from the response fields.
+Not everything the app's search box supports has an API filter. No list filter exists for: environment on/off state, rule shape (no rules, prerequisites, saved groups, linked experiments, temp rollouts), free-text description search, or created/updated date ranges — for those, fetch the (param-narrowed) set and filter client-side from the response fields. Staleness, drafts, and dependency lookups are better served by their dedicated endpoints (Path C below, `flag-revisions`, `flag-graph`) than by client-side filtering.
 
 Common searches:
 


### PR DESCRIPTION
## What

Updates `flag-search` for the new query params landing on `GET /api/v2/features` in [growthbook/growthbook#6419](https://github.com/growthbook/growthbook/pull/6419): `owner` (userId or email), `valueType`, `baseConfig`, `archived`, comma-separated `tag` values, and `sortBy`/`sortOrder`.

- **Path B reworked around API-side filtering.** "Flags owned by X" and "boolean flags" were fetch-every-page-then-filter-client-side; they're now single filtered calls. New rows for "recently changed flags" (`sortBy=dateUpdated&sortOrder=desc`) and "flags backed by config X" (`baseConfig=<config-key>`). Only environment state and rule shape still need client-side filtering, and the guidance now says to narrow with API params before paginating.
- **New guardrails:** owner filter values are userIds or emails (emails resolve to the org member; legacy flags storing a raw display name as owner match only that exact string), and "config" is not a `valueType` — config-backed flags are `json` flags filtered via `baseConfig`, and `valueType=config` 400s.
- **Fixes existing drift:** the skill already documented a `?tag=` filter, but the v2 list endpoint's strict query schema rejects unknown params with a 400 — that documented call never worked. These params make it real.
- **CHANGELOG** — Unreleased entry.

Sibling of #14 (experiments). Separate PR because each gates on a different GrowthBook API PR.

## ⚠ Depends on unreleased API changes

The params ship in [growthbook/growthbook#6419](https://github.com/growthbook/growthbook/pull/6419) (`gm/feature-api-filters`) and are not in any release yet. Keeping this draft until that change ships — against an older API these query params 400.

## Verification

Per CLAUDE.md, claims verified against the Zod validator (`listFeaturesV2Validator` in `packages/shared/src/validators/features-v2.ts`) and handler (`packages/back-end/src/api/features/listFeatures.ts`) on that branch: CSV params are `tag`/`owner`/`valueType`, `baseConfig` and `projectId` are single exact values, sortable fields are `id`/`dateCreated`/`dateUpdated` (omitting `sortBy` preserves insertion order), owner emails resolve via `resolveOwnerToUserId` with legacy free-text matched exactly, and `valueType` tokens are enum-validated (`boolean`/`string`/`number`/`json`) with a 400 on anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)